### PR TITLE
Добавлен параметр engines.node в package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,9 @@
         "ts-jest": "^27.0.3",
         "ts-node": "^10.2.1",
         "typescript": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@arkweid/lefthook": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "repository": "https://github.com/gooditworks/base",
   "author": "Max Eliseev <mxseev@gmail.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "scripts": {
     "postinstall": "sh ./scripts/add_base_remote.sh",
     "build": "tsc",


### PR DESCRIPTION
## Описание изменений

Добавлен параметр `engines.node >= 14`, который запрещает использование пакета нодой старше 14й версии

