### PR TITLE
Fault tolerant add_base_remote.sh скрипт

### DIFF
--- a/scripts/add_base_remote.sh
+++ b/scripts/add_base_remote.sh
@@ -1,9 +1,26 @@
 # Создаёт git remote на базовый репозиторий, если его (remote) ещё нет
 
-export BASE_REMOTE_URL=git@github.com:gooditcollective/base.git
+BASE_REMOTE_URL=git@github.com:gooditcollective/base.git
 
-# если мы НЕ в CI (github actions, vercel)
-if [ -z "$CI" ]; then
-  # создаёт remote, если его нет: https://stackoverflow.com/a/57936187
-  git config remote.base.url >&- || git remote add base $BASE_REMOTE_URL
+if [ -n "$CI" ]; then
+  echo "We in CI/CD, skipping"
+  exit 0
 fi
+
+if ! [ -x "$(command -v git)" ]; then
+  echo "git command not found, skipping"
+  exit 0
+fi
+
+if ! [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" ]; then
+  echo "Not a git repository, skipping"
+  exit 0
+fi
+
+if git config remote.base.url; then
+  echo "Base remote already set, skipping"
+  exit 0
+fi
+
+git remote add base $BASE_REMOTE_URL
+echo "Base remote added"


### PR DESCRIPTION
## Описание изменений

Скрипт `add_base_remote.sh` теперь проверяет:
- запуск в CI/CD
- отсутствие команды git
- отсутствие репозитория
- то, что remote уже проставлен

Во всех этих случаях он отображает адекватное сообщение и не пытается добавить remote

Fixes #55 

## Чеклист

- [x] проверена корректная работа скрипта во всех кейсах выше
