### PR TITLE
GHA для автоматического обновления обновления base теперь принимает кастомный токен

### DIFF
--- a/.github/workflows/base-update.yaml
+++ b/.github/workflows/base-update.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         if: steps.base_check.outputs.has_unmerged_commits == 'true'
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN || secrets.PAT }}
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           title: Update base repository
           branch: chore/base-update

--- a/.github/workflows/base-update.yaml
+++ b/.github/workflows/base-update.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         if: steps.base_check.outputs.has_unmerged_commits == 'true'
         with:
-          token: ${{ secrets.GITHUB_TOKEN || secrets.PAT }}
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           title: Update base repository
           branch: chore/base-update


### PR DESCRIPTION
## Проблема

По умолчанию при каждом запуске любого GHA ему даётся стандартный токен (`GITHUB_TOKEN`), у которого есть базовые права на этот репозиторий. Проблема в том, что у этого токена нет прав на `workflow`.

То есть, если при автоматическом обновлении базового репозитория затрагиваются файлы `.github/workflows/*` - [Github реджеткит этот пуш](https://github.com/gooditcollective/base-api/runs/7683442824?check_suite_focus=true#step:4:83), так как для изменения workflow нужны отдельные права

Решено довольно просто: теперь мы можем добавить любой токен (с нужными правами) в секреты (но по умолчанию всё равно будет использоваться обычный `GITHUB_TOKEN`)
